### PR TITLE
Polls toegevoegd + navigatiefix

### DIFF
--- a/Themes/default/Wireless.template.php
+++ b/Themes/default/Wireless.template.php
@@ -1245,10 +1245,10 @@ function template_smartphone_display()
 		      <article id="pollContents" style="display:none;">
 		      <div class="message">', $context['poll']['question'],'</div>';
 
-		      	//',((!$can_vote) ? $option['bar'] : ''),'
-		      	//<div class="bar" style="width: ',round($option['percent']),'px;">
-
 			foreach($context['poll']['options'] as $option){
+
+				$simplified_option = smartphone_simplify_body($option['option'], ''); //Ugly fix
+				$option['option'] = $simplified_option['body'];
 
 				echo '<label class="pollOption',($option['voted_this'] ? ' selected' : ''),'">',
 						(($can_vote)  ? $option['vote_button'] : ''), $option['option'], ((!$can_vote) ? ' (' . $option['percent'] . '%)' : '');

--- a/Themes/default/Wireless.template.php
+++ b/Themes/default/Wireless.template.php
@@ -1247,13 +1247,15 @@ function template_smartphone_display()
 
 		      	//',((!$can_vote) ? $option['bar'] : ''),'
 		      	//<div class="bar" style="width: ',round($option['percent']),'px;">
+
 			foreach($context['poll']['options'] as $option){
 
-				echo   '<label class="pollOption',($option['voted_this'] ? ' selected' : ''),'">
-						',(($can_vote)  ? $option['vote_button'] : ''),'
-						',$option['option'],'<br />
-						',((!$can_vote) ? $option['bar'] . '<br />' . $option['percent'] . '%' : ''), '
-					</label>';
+				echo '<label class="pollOption',($option['voted_this'] ? ' selected' : ''),'">',
+						(($can_vote)  ? $option['vote_button'] : ''), $option['option'], ((!$can_vote) ? ' (' . $option['percent'] . '%)' : '');
+						if (!$can_vote && $option['percent'] > 0) {
+							echo '<div class="bar" style="width: ', round($option['percent']), '%;"></div>';
+						}
+				echo '</label>';
 
 			}
 

--- a/Themes/default/Wireless.template.php
+++ b/Themes/default/Wireless.template.php
@@ -1207,10 +1207,6 @@ function template_smartphone_display()
 {
 	global $context, $settings, $options, $scripturl, $board, $txt;
 
-	//var_dump($context);
-
-	//if($context['page_info']['num_pages'] > 1){
-
 		echo '<header>
 		      <h1><a href="" data-onclick="reloader();" onclick="reloader();" id="reloader">', $context['page_title'], '</a></h1>
 		      <nav>';
@@ -1228,43 +1224,45 @@ function template_smartphone_display()
 		echo '      </nav>';
 		echo '    </header>';
 
-       // }
+	if($context['is_poll']){
 
+		$can_vote = true;
+		$can_change = ($context['poll']['change_vote'] == 1);
 
-	if($context['is_poll'] && 1 == 2){
+		if($context['poll']['has_voted'])
+			$can_vote = false;
 
+		if($context['poll']['is_expired'])
+			$can_vote = false;
+
+		if($context['poll']['is_locked'])
+			$can_vote = false;
 
 		echo '<form action="', $scripturl, '?action=vote;topic=', $context['current_topic'], '.', $context['start'], ';poll=',$context['poll']['id'],';smartphone" method="post" accept-charset="ISO-8859-1">';
+		
 		echo '<header>
-		      <h1>Poll</h1>
-		      <article>
+		      <h1 data-onclick="reloader(this);" onclick="togglePoll(this)">Poll (uitklappen)</h1>
+		      <article id="pollContents" style="display:none;">
 		      <div class="message">', $context['poll']['question'],'</div>';
-
-			$can_vote = true;
-
-			if($context['poll']['has_voted'])
-				$can_vote = false;
-
-			if($context['poll']['is_expired'])
-				$can_vote = false;
-
-			if($context['poll']['is_locked'])
-				$can_vote = false;
-
 
 		      	//',((!$can_vote) ? $option['bar'] : ''),'
 		      	//<div class="bar" style="width: ',round($option['percent']),'px;">
-
 			foreach($context['poll']['options'] as $option){
 
 				echo   '<label class="pollOption',($option['voted_this'] ? ' selected' : ''),'">
 						',(($can_vote)  ? $option['vote_button'] : ''),'
-						',$option['option'],'
+						',$option['option'],'<br />
+						',((!$can_vote) ? $option['bar'] . '<br />' . $option['percent'] . '%' : ''), '
 					</label>';
 
 			}
 
-
+			if ($can_vote) {
+				echo '<input type="hidden" name="sc" value="', $context['session_id'], '" />';
+				echo '<div class="autoWidth"><input type="submit" value="', $txt['smf23'], '"/></div>';
+			} else if ($can_change) {
+				echo '<div class="autoWidth"><a class="pollChange" href="', $scripturl, '?action=vote;topic=', $context['current_topic'], '.', $context['start'], ';poll=',$context['poll']['id'],';sesc=', $context['session_id'] ,';smartphone"/>', $txt['poll_change_vote'], '</a>';
+			}
 		echo '</article>';
 		echo '</header>';
 		echo '</form>';

--- a/Themes/default/Wireless.template.php
+++ b/Themes/default/Wireless.template.php
@@ -1813,12 +1813,6 @@ function template_smartphone_recent()
 
 		echo '<nav>
 		      <a href="/?smartphone" accesskey="0">', $txt[103], '</a>';
-		echo '<div class="pagerNav">';
-		echo !empty($context['links']['prev']) ? '<a class="pager" href="' . $context['links']['first'] . ';smartphone">&lt;&lt;</a> <a class="pager" href="' . $context['links']['prev'] . ';smartphone">&nbsp;&nbsp;&lt;&nbsp;&nbsp;</a> ' : '',
-		     '<div class="pagerText">Pagina ', $context['page_info']['current_page'], '/', max($context['page_info']['num_pages'],1), '</div>',
-		    !empty($context['links']['next']) ? ' <a class="pager" href="' . $context['links']['next'] . ';smartphone">&nbsp;&nbsp;&gt;&nbsp;&nbsp;</a> <a class="pager" href="' . $context['links']['last'] . ';smartphone">&gt;&gt;</a> ' : '';
-		echo '</div>';
-
 		echo '</nav>
 		      </header>';
 		echo '<section><h2>Topics</h2>';

--- a/Themes/default/Wireless.template.php
+++ b/Themes/default/Wireless.template.php
@@ -1224,7 +1224,7 @@ function template_smartphone_display()
 		echo '      </nav>';
 		echo '    </header>';
 
-	if($context['is_poll']){
+	if($context['is_poll'] && $context['page_info']['current_page'] == 1){
 
 		$can_vote = true;
 		$can_change = ($context['poll']['change_vote'] == 1);

--- a/smartphone/mobile.js
+++ b/smartphone/mobile.js
@@ -257,7 +257,21 @@ function reloader() {
 	document.getElementById('reloader').innerHTML = 'Herladen...';
 
 	location.reload(true);
-	
+
 	return true;
+
+}
+
+function togglePoll(header) {
+
+	var el;
+	el = document.getElementById('pollContents');
+	if (el.style.display == 'none') {
+		el.style.display = 'block';
+		header.innerHTML = 'Poll (inklappen)';
+	} else {
+		el.style.display = 'none';
+		header.innerHTML = 'Poll (uitklappen)';
+	}
 
 }

--- a/smartphone/style.css
+++ b/smartphone/style.css
@@ -147,9 +147,11 @@ header nav, section nav, footer nav, section article, header article, footer art
 		
 			label.pollOption div.bar {
 				
-				float: left;
+				margin-top: 5px;
 				width: 266px;
-				
+				background-color: red;
+				height: 12px;		
+
 			}
 		
 			label.pollOption input {

--- a/smartphone/style.css
+++ b/smartphone/style.css
@@ -149,9 +149,18 @@ header nav, section nav, footer nav, section article, header article, footer art
 				
 				margin-top: 5px;
 				width: 266px;
-				background-color: red;
-				height: 12px;		
-
+				height: 12px;
+				border-radius: 6px;
+				box-shadow: 0px 0px 2px #000;
+				-webkit-box-shadow: 0px 0px 2px #000;
+				background: #98ccfe;
+				background: -moz-linear-gradient(top, #98ccfe 0%, #5c8cbc 100%);
+				background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#98ccfe), color-stop(100%,#5c8cbc));
+				background: -webkit-linear-gradient(top, #98ccfe 0%,#5c8cbc 100%);
+				background: -o-linear-gradient(top, #98ccfe 0%,#5c8cbc 100%);
+				background: -ms-linear-gradient(top, #98ccfe 0%,#5c8cbc 100%);
+				background: linear-gradient(top, #98ccfe 0%,#5c8cbc 100%);
+				filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#98ccfe', endColorstr='#5c8cbc',GradientType=0 );
 			}
 		
 			label.pollOption input {

--- a/smartphone/style.css
+++ b/smartphone/style.css
@@ -514,3 +514,10 @@ div.quote, div.code, div.phpcode {
 		font-family: monospace;
 
 	}
+
+	a.pollChange {
+
+		color: #369;
+		text-decoration: none;
+
+	}


### PR DESCRIPTION
Proberen polls te implementeren (#31). Wil nog niet zeggen dat het het helemaal fixt, maar we zijn zo aardig op weg heb ik het idee.

Features:
- Poll alleen zichtbaar op pagina 1 van een topic, want je wilt hem vast niet altijd laden
- Poll is automatisch ingeklapt en kan uitgeklapt worden, zodat je bij lange polls gewoon het topic kunt lezen zonder eerst lang te moeten scrollen
- Stemmen zijn te plaatsen, te verwijderen en te bekijken vanuit gebruikersoogpunt.

Hetgeen wat aan deze implementatie nog scheelt is:
- De fix om afbeeldingen niet automatisch te laden, is niet al te mooi
- De labels zijn niet helemaal mooi qua hoogte, dit ligt er waarschijnlijk aan dat SMF automatisch de option elementen genereert, maar daar ben ik nog niet helemaal uit.
- Er is nog geen optie toegevoegd bij de instellingen om automatisch polls uit te klappen (zoals er wel is voor afbeeldingen), lijkt me wel een wenselijke feature.
- Polls toevoegen aan een topic, wijzigen, et cetera, lijkt me allemaal niet nodig om te implementeren.

Tot slot nog snel een navigatiefix toegevoegd, want bij de ongelezen berichten/reacties was het wel overdreven dat ook de paginanummers bovenin in de navigatie stonden. Nu is het beter (en gelijk met hoe het in topics is).
