### PR TITLE
Fix #60, /me wordt nu wel rood

### DIFF
--- a/smartphone/style.css
+++ b/smartphone/style.css
@@ -538,3 +538,7 @@ div.quote, div.code, div.phpcode {
 		text-decoration: none;
 
 	}
+
+    div.meaction {
+        color: red;
+    }


### PR DESCRIPTION
Viel eigenlijk best wel mee, de HTML wordt al meegegeven, dus het is slechts 3 extra regeltjes CSS om de /me rood te maken.
